### PR TITLE
Tidy the log

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -26,7 +26,7 @@ var (
 
 func main() {
 	flag.Parse()
-	log.WithField("version", GitInfoSHA).Info("start agent server...")
+	log.WithField("version", GitInfoSHA).Info("Start agent server...")
 
 	if *debug {
 		log.SetLevel(log.DebugLevel)
@@ -36,18 +36,18 @@ func main() {
 
 	lis, err := net.Listen("tcp", *agent)
 	if err != nil {
-		log.WithError(err).Fatalf("failed to listen: %v", *agent)
+		log.WithError(err).Fatalf("Failed to listen: %v.", *agent)
 	}
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
 
 	metaCfg, err := clients.NewMetaConfig(*agent, *meta, GitInfoSHA, *hbs)
 	if err != nil {
-		log.WithError(err).Fatalf("failed to create meta config")
+		log.WithError(err).Fatalf("Failed to create meta config.")
 	}
 	agentServer, err := server.NewAgent(metaCfg)
 	if err != nil {
-		log.WithError(err).Fatalf("failed to create agent server")
+		log.WithError(err).Fatalf("Failed to create agent server.")
 	}
 
 	pb.RegisterAgentServiceServer(grpcServer, agentServer)

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -22,7 +22,7 @@ func main() {
 	ctx := context.TODO()
 	c, err := agent.New(ctx, cfg)
 	if err != nil {
-		log.WithError(err).Fatalln("create agent client error")
+		log.WithError(err).Fatalln("Create agent client error.")
 	}
 
 	uploadReq := &pb.UploadFileRequest{
@@ -30,10 +30,10 @@ func main() {
 		SourcePath:    "local source path",
 		TargetBackend: &pb.Backend{Storage: &pb.Backend_Local{Local: &pb.Local{Path: "local target path"}}},
 	}
-	log.Infoln("start to upload file...")
+	log.Infoln("Start to upload file...")
 	_, e := c.UploadFile(uploadReq)
 	if e != nil {
-		log.WithError(e).Errorln("upload file failed")
+		log.WithError(e).Errorln("Upload file failed.")
 	}
-	log.Infoln("upload file successfully")
+	log.Infoln("Upload file successfully.")
 }

--- a/internal/clients/daemon.go
+++ b/internal/clients/daemon.go
@@ -82,7 +82,7 @@ func NewDaemon(s *Service) (*ServiceDaemon, error) {
 // check the service process status by other means in the future
 func (d *ServiceDaemon) Start() error {
 	cmdStr := fmt.Sprintf("cd %s && scripts/nebula.service start %s", d.s.dir, d.s.name)
-	log.WithField("cmd", cmdStr).Debug("Try to start service")
+	log.WithField("cmd", cmdStr).Debug("Try to start service...")
 	cmd := exec.Command("bash", "-c", cmdStr)
 	err := cmd.Run()
 	if err != nil {
@@ -94,7 +94,7 @@ func (d *ServiceDaemon) Start() error {
 
 func (d *ServiceDaemon) Stop() error {
 	cmdStr := fmt.Sprintf("cd %s && scripts/nebula.service stop %s", d.s.dir, d.s.name)
-	log.WithField("cmd", cmdStr).Debug("Try to stop service")
+	log.WithField("cmd", cmdStr).Debug("Try to stop service...")
 	cmd := exec.Command("bash", "-c", cmdStr)
 	err := cmd.Run()
 	if err != nil {
@@ -106,7 +106,7 @@ func (d *ServiceDaemon) Stop() error {
 
 func (d *ServiceDaemon) Status() (pb.Status, error) {
 	cmdStr := fmt.Sprintf("cd %s && scripts/nebula.service status %s", d.s.dir, d.s.name)
-	log.WithField("cmd", cmdStr).Debug("Try to get service's status")
+	log.WithField("cmd", cmdStr).Debug("Try to get service's status.")
 	cmd := exec.Command("bash", "-c", cmdStr)
 	outByte, err := cmd.Output()
 	if err != nil {

--- a/internal/clients/meta.go
+++ b/internal/clients/meta.go
@@ -31,11 +31,11 @@ func NewMetaConfig(agentAddr, metaAddr, gitSHA string, hbInterval int) (*MetaCon
 	var err error
 
 	if cfg.AgentAddr, err = utils.ParseAddr(agentAddr); err != nil {
-		log.WithError(err).WithField("address", agentAddr).Info("parse agent address failed")
+		log.WithError(err).WithField("address", agentAddr).Info("Parse agent address failed.")
 		return nil, err
 	}
 	if cfg.MetaAddr, err = utils.ParseAddr(metaAddr); err != nil {
-		log.WithError(err).WithField("address", metaAddr).Info("parse meta service address failed")
+		log.WithError(err).WithField("address", metaAddr).Info("Parse meta service address failed.")
 		return nil, err
 	}
 

--- a/internal/server/storage.go
+++ b/internal/server/storage.go
@@ -79,7 +79,7 @@ func (ss *StorageServer) DownloadFile(ctx context.Context, req *pb.DownloadFileR
 			"dst":        req.GetTargetPath(),
 			"recursive":  req.GetRecursively(),
 		},
-	).Debug("Download file to local machine")
+	).Debug("Download file to local machine.")
 
 	res := &pb.DownloadFileResponse{}
 	sto, err := ss.getStorage(req.GetSessionId(), req.GetSourceBackend())
@@ -97,7 +97,7 @@ func (ss *StorageServer) DownloadFile(ctx context.Context, req *pb.DownloadFileR
 
 // MoveDir rename file/dir in agent machine
 func (ss *StorageServer) MoveDir(ctx context.Context, req *pb.MoveDirRequest) (*pb.MoveDirResponse, error) {
-	log.WithField("src", req.GetSrcPath()).WithField("dst", req.GetDstPath()).Debug("Rename dir")
+	log.WithField("src", req.GetSrcPath()).WithField("dst", req.GetDstPath()).Debug("Rename dir.")
 	res := &pb.MoveDirResponse{}
 
 	_, err := os.Stat(req.GetSrcPath())
@@ -118,7 +118,7 @@ func (ss *StorageServer) MoveDir(ctx context.Context, req *pb.MoveDirRequest) (*
 
 // RemoveDir delete file/dir in agent machine
 func (ss *StorageServer) RemoveDir(ctx context.Context, req *pb.RemoveDirRequest) (*pb.RemoveDirResponse, error) {
-	log.WithField("path", req.GetPath()).Debug("Will delete dir")
+	log.WithField("path", req.GetPath()).Debug("Will delete dir.")
 	res := &pb.RemoveDirResponse{}
 
 	err := os.RemoveAll(req.GetPath())
@@ -131,7 +131,7 @@ func (ss *StorageServer) RemoveDir(ctx context.Context, req *pb.RemoveDirRequest
 
 // ExistDir check if file/dir in agent machine
 func (ss *StorageServer) ExistDir(ctx context.Context, req *pb.ExistDirRequest) (*pb.ExistDirResponse, error) {
-	log.WithField("path", req.GetPath()).Debug("Check if dir exist")
+	log.WithField("path", req.GetPath()).Debug("Check if dir exist.")
 	res := &pb.ExistDirResponse{Exist: false}
 
 	_, err := os.Stat(req.GetPath())

--- a/internal/utils/address.go
+++ b/internal/utils/address.go
@@ -14,7 +14,7 @@ func ParseAddr(host string) (*nebula.HostAddr, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &nebula.HostAddr{ipAddr[0], nebula.Port(port)}, nil
+	return &nebula.HostAddr{Host: ipAddr[0], Port: nebula.Port(port)}, nil
 }
 
 func StringifyAddr(addr *nebula.HostAddr) string {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,7 +44,7 @@ type client struct {
 
 func New(ctx context.Context, cfg *Config) (Client, error) {
 	addr := utils.StringifyAddr(cfg.Addr)
-	log.Debugln("Dail to address ", addr)
+	log.Debugf("Dialing to address %s.", addr)
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial agent service: %w", err)

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -134,7 +134,7 @@ func (l *Local) Upload(ctx context.Context, externalUri, localPath string, recur
 	dstPath := strings.TrimPrefix(externalUri, pb.LocalPrefix)
 	_, err := os.Stat(dstPath)
 	if !os.IsNotExist(err) {
-		log.WithField("path", externalUri).Info("Path to upload alredy exist")
+		log.WithField("path", externalUri).Info("Path to upload already exist")
 	}
 
 	// check local path
@@ -180,7 +180,7 @@ func (l *Local) Download(ctx context.Context, localPath, externalUri string, rec
 	// check local path
 	isExist, err := IsExist(localPath)
 	if isExist {
-		log.WithField("path", localPath).Info("Path to download alredy exist")
+		log.WithField("path", localPath).Info("Path to download already exist.")
 	}
 	if err != nil {
 		return fmt.Errorf("get local path: %s status failed: %w", localPath, err)
@@ -202,14 +202,14 @@ func (l *Local) Download(ctx context.Context, localPath, externalUri string, rec
 
 func (l *Local) ExistDir(ctx context.Context, uri string) bool {
 	if pb.ParseType(uri) != pb.LocalType {
-		log.Errorf("Invalid local uri type: %s", uri)
+		log.Errorf("Invalid local uri type: %s.", uri)
 		return false
 	}
 
 	p := strings.TrimPrefix(uri, pb.LocalPrefix)
 	exist, err := IsExist(p)
 	if err != nil {
-		log.WithError(err).Errorf("Check exist failed: %s", uri)
+		log.WithError(err).Errorf("Check exist failed: %s.", uri)
 		return false
 	}
 	return exist

--- a/pkg/storage/local_test.go
+++ b/pkg/storage/local_test.go
@@ -31,47 +31,47 @@ func toExternal(localname string) string {
 }
 
 func createFile(t *testing.T, filename string) {
-	t.Logf("create file %s", filename)
+	t.Logf("Create file %s.", filename)
 	f, err := os.Create(filename)
 	defer func() {
 		if err = f.Close(); err != nil {
-			t.Errorf("close file %s failed: %s", filename, err.Error())
+			t.Errorf("Close file %s failed: %s.", filename, err.Error())
 		}
 	}()
 
 	if err != nil {
-		t.Errorf("create %s error: %s", filename, err.Error())
+		t.Errorf("Create %s error: %s.", filename, err.Error())
 	} else {
 		if _, err = f.Write([]byte(filename)); err != nil {
-			t.Errorf("write content error: %s", err.Error())
+			t.Errorf("Write content error: %s.", err.Error())
 		}
 	}
 }
 
 func createDir(t *testing.T, dirname string) {
-	t.Logf("create dir %s", dirname)
+	t.Logf("Create dir %s.", dirname)
 	if err := os.MkdirAll(dirname, os.FileMode(0755)); err != nil {
-		t.Errorf("create dir %s failed: %s", dirname, err.Error())
+		t.Errorf("Create dir %s failed: %s.", dirname, err.Error())
 	}
 }
 
 func removeFile(t *testing.T, filename string) {
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		t.Logf("%s does not exist", filename)
+		t.Logf("%s does not exist.", filename)
 		return
 	}
 
 	if err := os.Remove(filename); err != nil {
-		t.Errorf("remove %s failed: %s", filename, err.Error())
+		t.Errorf("Remove %s failed: %s.", filename, err.Error())
 	}
-	t.Logf("has removed file %s", filename)
+	t.Logf("Has removed file %s.", filename)
 }
 
 func removeDir(t *testing.T, dirname string) {
 	if err := os.RemoveAll(dirname); err != nil {
-		t.Errorf("remove dir %s failed: %s", dirname, err.Error())
+		t.Errorf("Remove dir %s failed: %s.", dirname, err.Error())
 	}
-	t.Logf("has removed dir %s", dirname)
+	t.Logf("Has removed dir %s.", dirname)
 }
 
 func setup(t *testing.T) {

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -45,7 +45,7 @@ func NewS3(b *pb.Backend) (*S3, error) {
 	log.WithField("region", region).
 		WithField("endpoint", b.GetS3().GetEndpoint()).
 		WithField("forcePath", forcePath).
-		Debugf("Try to create s3 backend")
+		Debugf("Try to create s3 backend.")
 
 	return &S3{
 		backend: b,
@@ -81,7 +81,7 @@ func (s *S3) downloadToFile(file, key string) error {
 		return fmt.Errorf("download from %s to %s failed: %w", key, file, err)
 	}
 
-	log.Debugf("Download from %s to %s successfully, bytes=%d", key, file, numBytes)
+	log.Debugf("Download from %s to %s successfully, bytes=%d.", key, file, numBytes)
 	return nil
 }
 
@@ -112,7 +112,7 @@ func (s *S3) downloadPrefix(localDir, prefix string) error {
 		return fmt.Errorf("download %s recursively failed: %w", s.backend.Uri(), err)
 	}
 
-	log.Debugf("Download from %s to %s successfully", s.backend.Uri(), localDir)
+	log.Debugf("Download from %s to %s successfully.", s.backend.Uri(), localDir)
 	return nil
 }
 
@@ -147,7 +147,7 @@ func (s *S3) uploadToStorage(key, file string) error {
 		return fmt.Errorf("upload from %s to %s failed: %w", file, key, err)
 	}
 
-	log.Debugf("Upload from %s to %s successfully", file, key)
+	log.Debugf("Upload from %s to %s successfully.", file, key)
 	return nil
 }
 
@@ -168,7 +168,7 @@ func (s *S3) uploadPrefix(prefix, localDir string) error {
 	go func() {
 		// Gather the files to upload by walking the path recursively
 		if err := filepath.Walk(localDir, walker.Walk); err != nil {
-			log.Fatalln("Walk failed:", err)
+			log.WithError(err).Error("Walk failed.")
 		}
 		close(walker)
 	}()
@@ -178,17 +178,17 @@ func (s *S3) uploadPrefix(prefix, localDir string) error {
 	for path := range walker {
 		rel, err := filepath.Rel(localDir, path)
 		if err != nil {
-			log.Fatalln("Unable to get relative path:", path, err)
+			log.WithError(err).Errorf("Unable to get relative path: %s.", path)
 		}
 		key := filepath.Join(prefix, rel)
 
 		err = s.uploadToStorage(key, path)
 		if err != nil {
-			return fmt.Errorf("Upload from %s to %s failed: %w", path, key, err)
+			return fmt.Errorf("upload from %s to %s failed: %w", path, key, err)
 		}
 	}
 
-	log.Debugf("Upload from %s to %s recursively", localDir, s.backend.Uri())
+	log.Debugf("Upload from %s to %s recursively.", localDir, s.backend.Uri())
 	return nil
 }
 
@@ -210,7 +210,7 @@ func (s *S3) ExistDir(ctx context.Context, uri string) bool {
 	b := s.backend.DeepCopy()
 	err := b.SetUri(uri)
 	if err != nil {
-		log.WithError(err).WithField("uri", uri).Error("Check and set uri failed when test ExistDir")
+		log.WithError(err).WithField("uri", uri).Error("Check and set uri failed when test ExistDir.")
 		return false
 	}
 
@@ -259,12 +259,12 @@ func (s *S3) ListDir(ctx context.Context, uri string) ([]string, error) {
 	b := s.backend.DeepCopy()
 	err := b.SetUri(uri)
 	if err != nil {
-		return nil, fmt.Errorf("list dir, check and set s3 uri %s failed: %w", uri, err)
+		return nil, fmt.Errorf("list dir, check and set s3 uri %s failed: %w.", uri, err)
 	}
 
 	prefix := b.GetS3().GetPath()
 	if !strings.HasSuffix(prefix, "/") {
-		// without "/",  we could only get curr prefix
+		// without "/",  we could only get current prefix
 		prefix += "/"
 	}
 	req := &s3.ListObjectsV2Input{
@@ -282,7 +282,7 @@ func (s *S3) ListDir(ctx context.Context, uri string) ([]string, error) {
 			} else {
 				name, err = filepath.Rel(prefix, *obj.Prefix)
 				if err != nil {
-					log.WithError(err).WithField("key", *obj.Prefix).WithField("prefix", prefix).Error("Get relative path failed")
+					log.WithError(err).WithField("key", *obj.Prefix).WithField("prefix", prefix).Error("Get relative path failed.")
 					return false
 				}
 			}
@@ -318,7 +318,7 @@ func (s *S3) RemoveDir(ctx context.Context, uri string) error {
 
 			_, err = s.client.DeleteObject(delReq)
 			if err != nil {
-				log.WithError(err).WithField("key", *obj.Key).Errorf("Delete object %s failedln", *obj.Key)
+				log.WithError(err).WithField("key", *obj.Key).Errorf("Delete object %s failed.", *obj.Key)
 				return false
 			}
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -47,7 +47,7 @@ type ExternalStorage interface {
 }
 
 func New(b *pb.Backend) (ExternalStorage, error) {
-	log.WithField("uri", b.Uri()).Debugf("Create type: %s stoarge", b.Type())
+	log.WithField("uri", b.Uri()).Debugf("Create type: %s storage.", b.Type())
 
 	switch b.Type() {
 	case pb.LocalType:


### PR DESCRIPTION
1. Make the log starting with capital letter.
2. Add some punctuations in the end of log.
3. Using agent address when verify the version.